### PR TITLE
fix: rename noConsoleLog to noConsole for Biome 2.4.7

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -68,7 +68,7 @@
       },
       "suspicious": {
         "noExplicitAny": "error",
-        "noConsoleLog": "warn"
+        "noConsole": "warn"
       }
     }
   }


### PR DESCRIPTION
## Summary
- Renamed `noConsoleLog` to `noConsole` in `biome.json` — `noConsoleLog` doesn't exist in Biome 2.4.7

## Test plan
- [x] `biome check biome.json` passes without unknown key errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)